### PR TITLE
Filter Vanished Players from "Online"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,6 +140,10 @@
             <id>vault-repo</id>
             <url>http://nexus.hc.to/content/repositories/pub_releases</url>
         </repository>
+        <repository>
+            <id>essentials-repo</id>
+            <url>https://repo.essentialsx.net/releases/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -176,6 +180,12 @@
             <groupId>lv.id.bonne</groupId>
             <artifactId>panelutils</artifactId>
             <version>${panelutils.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>net.essentialsx</groupId>
+            <artifactId>EssentialsX</artifactId>
+            <version>2.19.0</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 
@@ -272,7 +282,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.3.1-SNAPSHOT</version>
+                <version>3.4.1</version>
                 <configuration>
                     <minimizeJar>true</minimizeJar>
                     <artifactSet>

--- a/src/main/java/world/bentobox/visit/VisitAddon.java
+++ b/src/main/java/world/bentobox/visit/VisitAddon.java
@@ -345,7 +345,7 @@ public class VisitAddon extends Addon
     private VaultHook vaultHook;
 
     /**
-     * Local variable that stores vault hook.
+     * Local variable that stores essentials hook.
      */
     private Essentials essentials;
 

--- a/src/main/java/world/bentobox/visit/VisitAddon.java
+++ b/src/main/java/world/bentobox/visit/VisitAddon.java
@@ -6,9 +6,11 @@
 package world.bentobox.visit;
 
 
+import com.earth2me.essentials.Essentials;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 
+import org.bukkit.plugin.Plugin;
 import world.bentobox.bank.Bank;
 import world.bentobox.bentobox.api.addons.Addon;
 import world.bentobox.bentobox.api.configuration.Config;
@@ -19,6 +21,8 @@ import world.bentobox.visit.commands.player.VisitPlayerCommand;
 import world.bentobox.visit.configs.Settings;
 import world.bentobox.visit.listeners.IslandLeaveListener;
 import world.bentobox.visit.managers.VisitAddonManager;
+
+import java.util.Optional;
 
 
 /**
@@ -226,6 +230,20 @@ public class VisitAddon extends Addon
             this.vaultHook = null;
             this.logWarning("Vault plugin not found. Economy will not work!");
         });
+
+        Optional<Plugin> essentials = Optional.ofNullable(Bukkit.getPluginManager().getPlugin("Essentials"));
+        essentials.ifPresentOrElse(hook -> {
+            this.essentials = (Essentials) hook;
+            if (this.essentials.isEnabled()) {
+                this.log("Visit Addon hooked into Essentials.");
+            }
+            else {
+                this.logWarning("Visit Addon could not hook into Essentials.");
+            }
+        }, () -> {
+            this.essentials = null;
+            this.logWarning("Essentials plugin not found!");
+        });
     }
 
 
@@ -252,6 +270,16 @@ public class VisitAddon extends Addon
         return this.vaultHook;
     }
 
+    /**
+     * This getter will allow to access to Essentials. It is written so that it could return null, if Essentials is not
+     * present.
+     *
+     * @return {@code Essentials} if it is present, {@code null} otherwise.
+     */
+    public Essentials getEssentials()
+    {
+        return this.essentials;
+    }
 
     /**
      * Gets bank hook.
@@ -315,6 +343,11 @@ public class VisitAddon extends Addon
      * Local variable that stores vault hook.
      */
     private VaultHook vaultHook;
+
+    /**
+     * Local variable that stores vault hook.
+     */
+    private Essentials essentials;
 
     /**
      * Local variable that stores bank addon hook.

--- a/src/main/java/world/bentobox/visit/VisitAddon.java
+++ b/src/main/java/world/bentobox/visit/VisitAddon.java
@@ -242,7 +242,6 @@ public class VisitAddon extends Addon
             }
         }, () -> {
             this.essentials = null;
-            this.logWarning("Essentials plugin not found!");
         });
     }
 

--- a/src/main/java/world/bentobox/visit/panels/player/VisitPanel.java
+++ b/src/main/java/world/bentobox/visit/panels/player/VisitPanel.java
@@ -837,7 +837,7 @@ public class VisitPanel
                         if (this.user.hasPermission("essentials.vanish.see")) return true;
 
                         /* If the owner is online, and is vanished filter them out */
-                        OfflinePlayer owner = Bukkit.getOfflinePlayer(Objects.requireNonNull(island.getOwner()));
+                        User owner = User.getInstance(Objects.requireNonNull(island.getOwner()));
                         /* If the owner is not online for some reason, bail */
                         if (!owner.isOnline()) return false;
 

--- a/src/main/java/world/bentobox/visit/panels/player/VisitPanel.java
+++ b/src/main/java/world/bentobox/visit/panels/player/VisitPanel.java
@@ -6,8 +6,12 @@
 package world.bentobox.visit.panels.player;
 
 
+import com.earth2me.essentials.Essentials;
+import org.bukkit.Bukkit;
 import org.bukkit.Material;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.World;
+import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.ClickType;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
@@ -824,6 +828,22 @@ public class VisitPanel
                 filter(island -> island.getMemberSet().stream().
                     map(User::getInstance).
                     anyMatch(User::isOnline)).
+                    filter(island -> {
+                        /* If essentials is not hooked, this filter doesn't apply */
+                        Essentials essentials = VisitAddon.getInstance().getEssentials();
+                        if (essentials == null) return true;
+
+                        /* If user can see vanished players, this filter does not apply */
+                        if (this.user.hasPermission("essentials.vanish.see")) return true;
+
+                        /* If the owner is online, and is vanished filter them out */
+                        OfflinePlayer owner = Bukkit.getOfflinePlayer(Objects.requireNonNull(island.getOwner()));
+                        /* If the owner is not online for some reason, bail */
+                        if (!owner.isOnline()) return false;
+
+                        /* If the target owner is vanished, do not include them as "online" */
+                        return !essentials.getVanishedPlayersNew().contains(owner.getName());
+                    }).
                 collect(Collectors.toList());
             case CAN_VISIT ->
                 // TODO: add balance and online check.

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -7,3 +7,5 @@ authors: [BONNe]
 contributors: ["The BentoBoxWorld Community"]
 website: https://bentobox.world
 description: ${project.description}
+
+softdepend: [Essentials]


### PR DESCRIPTION
Using EssentialsX, filter out vanished players from the "online" filter in the visit panel.